### PR TITLE
venice install

### DIFF
--- a/lib/inquirer.js
+++ b/lib/inquirer.js
@@ -1,4 +1,4 @@
-import { log, parseAnswers, inquirer } from "../utils";
+import { blue, parseAnswers, inquirer } from "../utils";
 
 // TODO - extract gettopic to here.
 
@@ -11,41 +11,72 @@ const dockerContainers = [
   "ksql-server",
   "postgres",
   "schema-registry",
-  "zookeeper"
+  "zookeeper",
+];
+
+const repos = [
+  "venice - Base pipeline with a postgres sink",
+  // "venice-python", // "Base pipeline that can connect to the python-producer-test and python-consumer"
+  "python-producer - Python-based streaming data Producer",
+  "python-consumer - Python-based streaming data Consumer",
 ];
 
 const queries = {
-  selectMultipleServices: async command => {
+  selectMultipleServices: async (command) => {
     const action = command === "log" ? "monitor" : "restart";
 
     const options = await inquirer.prompt({
       type: "checkbox",
       name: `${action}`,
-      message: log(
+      message: blue(
         `Select the Venice services which you would like to ${action}.\n` +
           "Press enter/return with no selection to exit.\n"
       ),
-      choices: dockerContainers
+      choices: dockerContainers,
     });
     return parseAnswers(options);
   },
-  selectSingleService: async command => {
+  selectSingleService: async (command) => {
     const action = command === "log" ? "monitor" : "restart";
     const answer = await inquirer.prompt({
       type: "list",
       name: `${action}`,
-      message: log(
+      message: blue(
         `Select the Venice service which you would like to ${action}.`
       ),
-      choices: dockerContainers
+      choices: dockerContainers,
     });
 
     return answer[action];
   },
 
-  promptUserInput: questions => {
+  selectRepo: async () => {
+    let questions = [
+      {
+        type: "list",
+        name: "repo",
+        message: blue(`Select the Venice service you would like to install.`),
+        choices: repos,
+      },
+    ];
+    return await inquirer.prompt(questions);
+  },
+
+  confirm: async (action, service) => {
+    let questions = [
+      {
+        type: "list",
+        name: "affirm",
+        message: blue(`Are you sure you'd like to ${action} ${service}?`),
+        choices: ["yes", "no"],
+      },
+    ];
+    return await inquirer.prompt(questions);
+  },
+
+  promptUserInput: (questions) => {
     return inquirer.prompt(questions);
-  }
+  },
 };
 
 module.exports = queries;

--- a/lib/inquirer.js
+++ b/lib/inquirer.js
@@ -15,7 +15,7 @@ const dockerContainers = [
 ];
 
 const repos = [
-  "venice - Base pipeline with a postgres sink",
+  "venice - Base pipeline with a Postgres sink",
   // "venice-python", // "Base pipeline that can connect to the python-producer-test and python-consumer"
   "python-producer - Python-based streaming data Producer",
   "python-consumer - Python-based streaming data Consumer",
@@ -65,10 +65,9 @@ const queries = {
   confirm: async (action, service) => {
     let questions = [
       {
-        type: "list",
+        type: "confirm",
         name: "affirm",
         message: blue(`Are you sure you'd like to ${action} ${service}?`),
-        choices: ["yes", "no"],
       },
     ];
     return await inquirer.prompt(questions);

--- a/src/cli.js
+++ b/src/cli.js
@@ -5,6 +5,7 @@ const { parseSchemaCommand } = require("./schemas");
 const { error } = require("../utils");
 const { startCLI } = require("./ksql");
 const { displayManual } = require("./manual");
+const { install } = require("./install");
 
 //  URLS - eventually these should all be docker URLS or ENV variables - can this line be removed?
 
@@ -15,24 +16,24 @@ const { displayManual } = require("./manual");
 // we should remove it from the list of containers to log or restart in inquirer
 // and from the list of commands in manual
 
-const checkForAlias = command => {
+const checkForAlias = (command) => {
   const aliases = {
     "-c": "connectors",
     "-es": "elasticsearch",
     "-k": "ksql",
     "-l": "logs",
-    "-p": "postgres",
+    "-i": "install",
     "-r": "restart",
     "-s": "schemas",
     "-st": "status",
     "-t": "topics",
-    "--help": "man"
+    "--help": "man",
   };
 
   return aliases[command] || command;
 };
 
-const argumentsIntoOptions = rawArgs => {
+const argumentsIntoOptions = (rawArgs) => {
   let service = rawArgs[2];
   const command = rawArgs[3] || false;
   service = checkForAlias(service);
@@ -67,7 +68,8 @@ export function cli(rawArgs) {
       displayManual();
       break;
 
-    case "postgres": // pull down the venice postgres sink from github
+    case "install":
+      install();
       break;
 
     case "psql":

--- a/src/install.js
+++ b/src/install.js
@@ -20,16 +20,19 @@ const install = {
   install: async () => {
     const answer = await selectRepo();
     const repo = answer.repo.split(" - ")[0];
-    let options = {
+    const options = {
       directoryName: repoURLs[repo][0],
       repoURL: repoURLs[repo][1],
     };
-    log(`${options.directoryName}, ${options.repoURL}`);
+    // log(`${options.directoryName}, ${options.repoURL}`);
 
-    // parse answer to construct command
-    confirm("download and install", repo); // confirm before installing
-    // if no quit
-    // if yes, pass in command
+    let confirmation = await confirm("download and install", repo); // confirm before installing
+    if (!confirmation) {
+      return;
+    } else {
+      const command = `git clone ${options.repoURL} ${options.directoryName}`;
+      log(command);
+    }
   },
 };
 

--- a/src/install.js
+++ b/src/install.js
@@ -1,4 +1,4 @@
-const { log } = require("../utils");
+const { blue, error, execPromise, log, Spinner } = require("../utils");
 const { selectRepo, confirm } = require("../lib/inquirer");
 
 const repoURLs = {
@@ -7,12 +7,12 @@ const repoURLs = {
     "git@github.com:venice-framework/venice.git",
   ],
   "python-producer": [
-    "python-producer",
-    "git@github.com/venice-framework/python-producer-test",
+    "bus-producer-test",
+    "git@github.com:venice-framework/python-producer-test.git",
   ],
   "python-consumer": [
     "python-consumer",
-    "git@github.com/venice-framework/python-consumer",
+    "git@github.com:venice-framework/python-consumer.git",
   ],
 };
 
@@ -24,14 +24,30 @@ const install = {
       directoryName: repoURLs[repo][0],
       repoURL: repoURLs[repo][1],
     };
-    // log(`${options.directoryName}, ${options.repoURL}`);
 
-    let confirmation = await confirm("download and install", repo); // confirm before installing
-    if (!confirmation) {
+    let confirmation = await confirm("download and install", repo);
+    if (!confirmation.affirm) {
       return;
     } else {
-      const command = `git clone ${options.repoURL} ${options.directoryName}`;
-      log(command);
+      const cmd = `git clone ${options.repoURL} ${options.directoryName}`;
+      const status = new Spinner(
+        blue(`Venice is downloading ${repo}. Please wait...`)
+      );
+
+      const download = execPromise(cmd);
+      status.start();
+      download
+        .then(() => {
+          log(`\n\nSUCCESS: venice component ${repo} was installed!`);
+          log(
+            `enter 'cd ${options.directoryName}' if you need to navigate into` +
+              " that directory."
+          );
+        })
+        .catch((err) => error(err))
+        .finally(() => {
+          status.stop();
+        });
     }
   },
 };

--- a/src/install.js
+++ b/src/install.js
@@ -1,0 +1,28 @@
+const { log } = require("../utils");
+const { selectRepo, confirm } = require("../lib/inquirer");
+
+const repoURLs = {
+  venice: ["venice", "git@github.com:venice-framework/venice.git"],
+  "python-producer": [
+    "python-producer-test",
+    "git@github.com/venice-framework/python-producer-test",
+  ],
+  "python-consumer": [
+    "python-consumer",
+    "git@github.com/venice-framework/python-consumer",
+  ],
+};
+
+const install = {
+  install: async () => {
+    const answers = await selectRepo();
+    log(answers.repo);
+
+    // parse answer to construct command
+    confirm("download and install", "this repo"); // confirm before installing
+    // if no quit
+    // if yes, pass in command
+  },
+};
+
+module.exports = install;

--- a/src/install.js
+++ b/src/install.js
@@ -2,9 +2,12 @@ const { log } = require("../utils");
 const { selectRepo, confirm } = require("../lib/inquirer");
 
 const repoURLs = {
-  venice: ["venice", "git@github.com:venice-framework/venice.git"],
+  venice: [
+    "venice-postgres-sink",
+    "git@github.com:venice-framework/venice.git",
+  ],
   "python-producer": [
-    "python-producer-test",
+    "python-producer",
     "git@github.com/venice-framework/python-producer-test",
   ],
   "python-consumer": [
@@ -15,11 +18,16 @@ const repoURLs = {
 
 const install = {
   install: async () => {
-    const answers = await selectRepo();
-    log(answers.repo);
+    const answer = await selectRepo();
+    const repo = answer.repo.split(" - ")[0];
+    let options = {
+      directoryName: repoURLs[repo][0],
+      repoURL: repoURLs[repo][1],
+    };
+    log(`${options.directoryName}, ${options.repoURL}`);
 
     // parse answer to construct command
-    confirm("download and install", "this repo"); // confirm before installing
+    confirm("download and install", repo); // confirm before installing
     // if no quit
     // if yes, pass in command
   },

--- a/utils.js
+++ b/utils.js
@@ -1,5 +1,5 @@
 // const chalk = require("chalk");
-const clear = require("clear");
+// const clear = require("clear");
 const clui = require("clui");
 const color = require("cli-color");
 const exec = require("child_process").exec;
@@ -15,7 +15,7 @@ const orange = color.xterm(209);
 
 const util = {
   blue,
-  clear,
+  // clear,
   clui,
   color,
   exec,
@@ -25,11 +25,11 @@ const util = {
   inquirer,
   spawnPromise,
   Spinner,
-  log: msg => {
+  log: (msg) => {
     console.log(blue(msg));
   },
 
-  error: msg => {
+  error: (msg) => {
     console.log(orange(msg));
   },
 
@@ -41,13 +41,13 @@ const util = {
     console.log(blue("--------------------------------------------------"));
   },
 
-  parseAnswers: options => {
+  parseAnswers: (options) => {
     let values = [];
     for (let [key1, value1] of Object.entries(options)) {
       for (let [key2, value2] of Object.entries(value1)) values.push(value2);
     }
     return values.join(" ");
-  }
+  },
 };
 
 module.exports = util;


### PR DESCRIPTION
Adds `venice install` (or `venice -i`) functionality to clone one of our repos.  
- user is prompted to select one of (currently three) existing repos - each has a label identifying what it is
- options are: 
  - venice - base pipeline with a Postgres sink
  - python-producer - Python-based streaming data Producer
  - python-consumer - Python-based streaming data Consumer

These map to the following directories (as outlined in the quickstart):
venice-postgres-sink
bus-producer-test 
python-consumer 

Names and descriptions are easy to change. 

once the download completes, the user is notified that the download was successful and the name of the new directory and promoted to `cd` into it in case they need to navigate into it. 