### PR TITLE
Change to HTTPS from SSH repo commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Steps:
 
 1. Clone this repository
 
-- `git clone git@github.com:venice-framework/venice-cli.git`
+- `git clone https://github.com/venice-framework/venice-cli.git`
 
 2. Navigate into the newly installed `venice-cli` directory
 
@@ -31,7 +31,7 @@ Steps:
 
 Or use this single command that combines the four steps above:
 
-`git clone git@github.com:venice-framework/venice-cli.git && cd venice-cli && npm install && sudo npm link`
+`git clone https://github.com/venice-framework/venice-cli.git && cd venice-cli && npm install && sudo npm link`
 
 **Now you're ready to use the CLI from any console interface!** (It shouldn't be limited to this directory.)
 
@@ -76,9 +76,9 @@ Issue the following commands to use the Venice framework
 
 #### Topic Commands
 
-| Command     | Alias   | Function                                                     |
-| :---------- | :------ | :----------------------------------------------------------- |
-| topics      | -t      | view a list of the current topics                            |
+| Command     | Alias   | Function                                     |
+| :---------- | :------ | :------------------------------------------- |
+| topics      | -t      | view a list of the current topics            |
 | topics show | -t show | view the event stream from an existing topic |
 
 ##### Notes

--- a/src/install.js
+++ b/src/install.js
@@ -4,15 +4,15 @@ const { selectRepo, confirm } = require("../lib/inquirer");
 const repoURLs = {
   venice: [
     "venice-postgres-sink",
-    "git@github.com:venice-framework/venice.git",
+    "https://github.com/venice-framework/venice.git",
   ],
   "python-producer": [
     "bus-producer-test",
-    "git@github.com:venice-framework/python-producer-test.git",
+    "https://github.com/venice-framework/python-producer-test.git",
   ],
   "python-consumer": [
     "python-consumer",
-    "git@github.com:venice-framework/python-consumer.git",
+    "https://github.com/venice-framework/python-consumer.git",
   ],
 };
 


### PR DESCRIPTION
Because not all systems will have SSH set up, the HTTPS links for installing repos will be more universally useful.